### PR TITLE
Add Swift 6.1 installation to GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Setup Swift
+      uses: swift-actions/setup-swift@v2
+      with:
+        swift-version: "6.1"
+    
     - name: Run Swift Macro Compatibility Check Script
       shell: bash
       run: |


### PR DESCRIPTION
## Summary
- Enhances the GitHub Action to automatically install Swift 6.1 using swift-actions/setup-swift@v2
- Makes the action self-contained and eliminates dependency on pre-installed Swift on runners

## Test plan
- [ ] Test action works on runners without pre-installed Swift
- [ ] Verify Swift 6.1 installation completes successfully
- [ ] Confirm existing compatibility checks still function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)