### PR TITLE
Add new swift-syntax versions 601.0.0 and 601.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ The action tests against the following `swift-syntax` versions:
 - `510.0.3`
 - `600.0.0`
 - `600.0.1`
+- `601.0.0`
+- `601.0.1`
 
-When `major-versions-only` is set to `true`, only versions `509.0.0`, `510.0.0`, and `600.0.0` are tested.
+When `major-versions-only` is set to `true`, only versions `509.0.0`, `510.0.0`, `600.0.0`, and `601.0.0` are tested.
 
 ## Running the Script Locally
 

--- a/swift-macro-compatibility-check.sh
+++ b/swift-macro-compatibility-check.sh
@@ -34,6 +34,8 @@ ALL_VERSIONS=(
   "510.0.3"
   "600.0.0"
   "600.0.1"
+  "601.0.0"
+  "601.0.1"
 )
 
 # List of major swift-syntax versions
@@ -41,6 +43,7 @@ MAJOR_VERSIONS=(
   "509.0.0"
   "510.0.0"
   "600.0.0"
+  "601.0.0"
 )
 
 # Choose which versions to use based on input


### PR DESCRIPTION
## Summary
- Add swift-syntax versions 601.0.0 and 601.0.1 to the compatibility check
- Update both shell script and README.md documentation
- Include 601.0.0 in major versions list for compatibility testing

## Test plan
- [ ] Verify the new versions are included in the ALL_VERSIONS array
- [ ] Verify 601.0.0 is included in the MAJOR_VERSIONS array
- [ ] Confirm README.md documentation reflects the new versions
- [ ] Run the action to ensure compatibility with the new versions