### PR TITLE
Introduce `from-version` param

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ jobs:
 |-----------------------|---------------------------------------------------------------|----------|---------|
 | `run-tests`           | Whether to run tests (true/false)                             | false    | false   |
 | `major-versions-only` | Whether to test only against major versions (true/false)      | false    | false   |
+| `from-version`        | Check starting from this `swift-syntax` version (e.g. 510.0.0) | false    |         |
 | `verbose`             | Whether to use verbose output for Swift commands (true/false) | false    | false   |
 
 ## `swift-syntax` Versions
@@ -71,6 +72,8 @@ The action tests against the following `swift-syntax` versions:
 
 When `major-versions-only` is set to `true`, only versions `509.0.0`, `510.0.0`, `600.0.0`, and `601.0.1` are tested.
 
+When `from-version` is set, versions older than it are skipped (after applying `major-versions-only`, if enabled).
+
 ## Running the Script Locally
 
 If you'd like to run the compatibility check script locally without GitHub Actions, you can do so by executing the provided bash script [`swift-macro-compatibility-check.sh`](swift-macro-compatibility-check.sh) in your terminal.
@@ -78,7 +81,7 @@ If you'd like to run the compatibility check script locally without GitHub Actio
 ### Usage
 
 ```bash
-./swift-macro-compatibility-check.sh [--run-tests] [--major-versions-only] [--verbose]
+./swift-macro-compatibility-check.sh [--run-tests] [--major-versions-only] [--from-version <version>] [--verbose]
 ```
 
 ### Script Overview
@@ -127,6 +130,7 @@ jobs:
         with:
           run-tests: 'true'
           major-versions-only: 'false'
+          from-version: '510.0.0'
           verbose: 'true'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,11 @@ inputs:
     required: false
     default: 'false'
 
+  from-version:
+    description: 'Check starting from this swift-syntax version (e.g. 510.0.0); empty means all selected versions'
+    required: false
+    default: ''
+
   verbose:
     description: 'Whether to use verbose output for Swift commands (true/false)'
     required: false
@@ -24,20 +29,22 @@ runs:
     - name: Run Swift Macro Compatibility Check Script
       shell: bash
       run: |
-        # Pass input values to the script
-        ARGS=""
+        args=()
         if [ "${{ inputs.run-tests }}" = "true" ]; then
-          ARGS="$ARGS --run-tests"
+          args+=(--run-tests)
         fi
         if [ "${{ inputs.major-versions-only }}" = "true" ]; then
-          ARGS="$ARGS --major-versions-only"
+          args+=(--major-versions-only)
+        fi
+        from_version="${{ inputs.from-version }}"
+        if [ -n "$from_version" ]; then
+          args+=(--from-version "$from_version")
         fi
         if [ "${{ inputs.verbose }}" = "true" ]; then
-          ARGS="$ARGS --verbose"
+          args+=(--verbose)
         fi
 
-        # Execute the external script with the arguments
-        bash ${{ github.action_path }}/swift-macro-compatibility-check.sh $ARGS
+        bash "${{ github.action_path }}/swift-macro-compatibility-check.sh" "${args[@]}"
 
 branding:
   icon: 'check-circle'

--- a/swift-macro-compatibility-check.sh
+++ b/swift-macro-compatibility-check.sh
@@ -2,19 +2,54 @@
 
 # Swift Macro Compatibility Check Script
 # Usage:
-# ./swift-macro-compatibility-check.sh [--run-tests] [--major-versions-only] [--verbose]
+# ./swift-macro-compatibility-check.sh [--run-tests] [--major-versions-only] [--from-version <version>] [--verbose]
 
 # Default input values
 RUN_TESTS=false
 MAJOR_VERSIONS_ONLY=false
+FROM_VERSION=""
 VERBOSE=false
 FAILURE_OCCURRED=false
+
+# Validate version format (e.g. 510.0.0)
+function is_valid_version() {
+  local v="$1"
+  [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+}
+
+# Returns success if $1 >= $2 (dot-separated numeric)
+function version_ge() {
+  local a="$1"
+  local b="$2"
+
+  local a1 a2 a3 b1 b2 b3
+  IFS='.' read -r a1 a2 a3 <<< "$a"
+  IFS='.' read -r b1 b2 b3 <<< "$b"
+
+  if (( a1 != b1 )); then
+    (( a1 > b1 ))
+    return
+  fi
+  if (( a2 != b2 )); then
+    (( a2 > b2 ))
+    return
+  fi
+  (( a3 >= b3 ))
+}
 
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --run-tests) RUN_TESTS=true ;;
         --major-versions-only) MAJOR_VERSIONS_ONLY=true ;;
+        --from-version)
+          shift
+          if [ -z "${1:-}" ]; then
+            echo "Missing value for --from-version (expected e.g. 510.0.0)" >&2
+            exit 2
+          fi
+          FROM_VERSION="$1"
+          ;;
         --verbose) VERBOSE=true ;;
         *) echo "Unknown parameter: $1" ;;
     esac
@@ -51,6 +86,26 @@ if [ "$MAJOR_VERSIONS_ONLY" = true ]; then
   VERSIONS=("${MAJOR_VERSIONS[@]}")
 else
   VERSIONS=("${ALL_VERSIONS[@]}")
+fi
+
+if [ -n "$FROM_VERSION" ]; then
+  if ! is_valid_version "$FROM_VERSION"; then
+    echo "Invalid --from-version '$FROM_VERSION' (expected format: 510.0.0)" >&2
+    exit 2
+  fi
+
+  FILTERED_VERSIONS=()
+  for version in "${VERSIONS[@]}"; do
+    if version_ge "$version" "$FROM_VERSION"; then
+      FILTERED_VERSIONS+=("$version")
+    fi
+  done
+
+  if [ ${#FILTERED_VERSIONS[@]} -eq 0 ]; then
+    echo "No swift-syntax versions to check (from-version '$FROM_VERSION' is newer than all selected versions)" >&2
+    exit 2
+  fi
+  VERSIONS=("${FILTERED_VERSIONS[@]}")
 fi
 
 # Set verbosity flag


### PR DESCRIPTION
## Description

Adds a new from-version input/flag to start the matrix at a specific swift-syntax version and skip older versions.

## Motivation

While it's good to support as many versions as possible, as time goes on developers will start dropping very old versions of Swift/Swift Syntax and so this action should allow specifying a starting point newer than the default 509.0.0.

## Example

As an example, I use this for one of my libraries with compatibility starting at Swift 6.0 https://github.com/davdroman/swiftui-color-macros/pull/2